### PR TITLE
feat: add FormzMixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.0
+
+- Add `FormzMixin`
+- Fix `Formz.validate` to take `pure` into consideration
+- Lint improvements
+
 # 0.2.0
 
 - Remove redundant extensions on `FormzInputStatus`

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ final invalidInputs = <FormzInput>[
 print(Formz.validate(invalidInputs)); // FormzStatus.invalid
 ```
 
-## Automatically FormzStatus Computation
+## Automatic `FormzStatus` Computation
 
 ```dart
 class LoginForm with FormzMixin {

--- a/README.md
+++ b/README.md
@@ -71,3 +71,23 @@ final invalidInputs = <FormzInput>[
 
 print(Formz.validate(invalidInputs)); // FormzStatus.invalid
 ```
+
+## Automatically FormzStatus Computation
+
+```dart
+class LoginForm with FormzMixin {
+  LoginForm({
+    this.username = const Username.pure(),
+    this.password = const Password.pure(),
+  });
+
+  final Username username;
+  final Password password;
+
+  @override
+  List<FormzInput> get inputs => [username, password];
+}
+
+final form = LoginForm();
+print(form.status); // FormzStatus.pure
+```

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,7 +7,7 @@ analyzer:
 
 linter:
   rules:
-    # - public_member_api_docs
+    - public_member_api_docs
     - annotate_overrides
     - avoid_empty_else
     - avoid_function_literals_in_foreach_calls

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,11 +1,81 @@
-include: package:effective_dart/analysis_options.yaml
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+  exclude:
+    - test/.test_coverage.dart
 
 linter:
   rules:
-    prefer_relative_imports: false
-    avoid_equals_and_hash_code_on_mutable_classes: false
-    sort_constructors_first: true
-
-analyzer:
-  exclude:
-    - test/.test_coverage.dart
+    # - public_member_api_docs
+    - annotate_overrides
+    - avoid_empty_else
+    - avoid_function_literals_in_foreach_calls
+    - avoid_init_to_null
+    - avoid_null_checks_in_equality_operators
+    - avoid_relative_lib_imports
+    - avoid_renaming_method_parameters
+    - avoid_return_types_on_setters
+    - avoid_returning_null
+    - avoid_types_as_parameter_names
+    - avoid_unused_constructor_parameters
+    - await_only_futures
+    - camel_case_types
+    - cancel_subscriptions
+    - cascade_invocations
+    - comment_references
+    - constant_identifier_names
+    - control_flow_in_finally
+    - directives_ordering
+    - empty_catches
+    - empty_constructor_bodies
+    - empty_statements
+    - hash_and_equals
+    - implementation_imports
+    - invariant_booleans
+    - iterable_contains_unrelated_type
+    - library_names
+    - library_prefixes
+    - list_remove_unrelated_type
+    - lines_longer_than_80_chars
+    - no_adjacent_strings_in_list
+    - no_duplicate_case_values
+    - non_constant_identifier_names
+    - null_closures
+    - omit_local_variable_types
+    - only_throw_errors
+    - overridden_fields
+    - package_api_docs
+    - package_names
+    - package_prefixed_library_names
+    - prefer_adjacent_string_concatenation
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_contains
+    - prefer_equal_for_default_values
+    - prefer_final_fields
+    - prefer_initializing_formals
+    - prefer_interpolation_to_compose_strings
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_single_quotes
+    - prefer_typing_uninitialized_variables
+    - recursive_getters
+    - slash_for_doc_comments
+    - sort_constructors_first
+    - test_types_in_equals
+    - throw_in_finally
+    - type_init_formals
+    - unawaited_futures
+    - unnecessary_brace_in_string_interps
+    - unnecessary_const
+    - unnecessary_getters_setters
+    - unnecessary_lambdas
+    - unnecessary_new
+    - unnecessary_null_aware_assignments
+    - unnecessary_statements
+    - unnecessary_this
+    - unrelated_type_equality_checks
+    - use_rethrow_when_possible
+    - valid_regexps

--- a/example/main.dart
+++ b/example/main.dart
@@ -19,20 +19,20 @@ class NameInput extends FormzInput<String, NameInputError> {
 }
 
 void main() {
-  final name = NameInput.pure();
+  const name = NameInput.pure();
   print(name.value); // ''
   print(name.valid); // false
   print(name.status); // FormzInputStatus.pure
   print(name.error); // NameInputError.empty
 
-  final joe = NameInput.dirty(value: 'joe');
+  const joe = NameInput.dirty(value: 'joe');
   print(joe.value); // 'joe'
   print(joe.valid); // true
   print(joe.status); // FormzInputStatus.valid
   print(joe.error); // null
   print(joe.toString()); // NameInput('joe', true);
 
-  final validInputs = <FormzInput>[
+  const validInputs = <FormzInput>[
     NameInput.dirty(value: 'jan'),
     NameInput.dirty(value: 'jen'),
     NameInput.dirty(value: 'joe'),
@@ -40,7 +40,7 @@ void main() {
 
   print(Formz.validate(validInputs)); // FormzStatus.valid
 
-  final invalidInputs = <FormzInput>[
+  const invalidInputs = <FormzInput>[
     NameInput.dirty(value: ''),
     NameInput.dirty(value: ''),
     NameInput.dirty(value: ''),

--- a/lib/formz.dart
+++ b/lib/formz.dart
@@ -173,8 +173,11 @@ class Formz {
   }
 }
 
-/// Mixin which handles automatically
-/// validating one or more [FormzInput] instances.
+/// Mixin that automatically handles validation of all [FormzInput]s present in
+/// the [inputs].
+///
+/// When mixing this in, you are required to override the [inputs] getter and
+/// provide all [FormzInput]s you want to automatically validate.
 ///
 /// ```dart
 /// class LoginFormState with FormzMixin {

--- a/lib/formz.dart
+++ b/lib/formz.dart
@@ -196,5 +196,8 @@ mixin FormzMixin {
   FormzStatus get status => Formz.validate(inputs);
 
   /// Returns all [FormzInput] instances.
+  ///
+  /// Override this and give it all [FormzInput]s in your class that should be
+  /// validated automatically.
   List<FormzInput> get inputs;
 }

--- a/lib/formz.dart
+++ b/lib/formz.dart
@@ -74,7 +74,7 @@ enum FormzInputStatus {
 /// It contains information about the [FormzInputStatus], [value], as well
 /// as validation status.
 ///
-/// [FormzInput] should be extended to define custom [FormzInputs].
+/// [FormzInput] should be extended to define custom [FormzInput] instances.
 ///
 /// ```dart
 /// enum FirstNameError { empty }
@@ -165,8 +165,36 @@ class Formz {
   /// Returns a [FormzStatus] given a list of [FormzInput].
   static FormzStatus validate(List<FormzInput> inputs) {
     assert(inputs != null);
-    return inputs.any((input) => input.valid == false)
-        ? FormzStatus.invalid
-        : FormzStatus.valid;
+    return inputs.every((element) => element.pure)
+        ? FormzStatus.pure
+        : inputs.any((input) => input.valid == false)
+            ? FormzStatus.invalid
+            : FormzStatus.valid;
   }
+}
+
+/// Mixin which handles automatically
+/// validating one or more [FormzInput] instances.
+///
+/// ```dart
+/// class LoginFormState with FormzMixin {
+///  LoginFormState({
+///    this.username = const Username.pure(),
+///    this.password = const Password.pure(),
+///  });
+///
+///  final Username username;
+///  final Password password;
+///
+///  @override
+///  List<FormzInput> get inputs => [username, password];
+/// }
+/// ```
+mixin FormzMixin {
+  /// [FormzStatus] getter which computes the status based on the
+  /// validity of the [inputs].
+  FormzStatus get status => Formz.validate(inputs);
+
+  /// Returns all [FormzInput] instances.
+  List<FormzInput> get inputs;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,13 +3,13 @@ description: A unified form representation in Dart which aims to simplify form r
 repository: https://github.com/ChicagoFlutter/formz
 issue_tracker: https://github.com/ChicagoFlutter/formz/issues
 homepage: https://github.com/ChicagoFlutter/formz
+documentation: https://github.com/ChicagoFlutter/formz
 
-version: 0.2.0
+version: 0.3.0
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dev_dependencies:
-  effective_dart: ^1.2.0
   test: ^1.14.2
   test_coverage: ^0.4.1

--- a/test/formz_test.dart
+++ b/test/formz_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: prefer_const_constructors
 import 'package:formz/formz.dart';
 import 'package:test/test.dart';
 
@@ -5,6 +6,26 @@ import 'helpers/helpers.dart';
 
 void main() {
   group('Formz', () {
+    group('FormzMixin', () {
+      test('status returns pure', () {
+        expect(NameInputFormzMixin().status, FormzStatus.pure);
+      });
+
+      test('status returns invalid', () {
+        expect(
+          NameInputFormzMixin(name: const NameInput.dirty(value: '')).status,
+          FormzStatus.invalid,
+        );
+      });
+
+      test('status returns valid', () {
+        expect(
+          NameInputFormzMixin(name: const NameInput.dirty(value: 'joe')).status,
+          FormzStatus.valid,
+        );
+      });
+    });
+
     group('FormzInput', () {
       test('constructor throws AssertionError when value is null', () {
         expect(
@@ -127,10 +148,11 @@ void main() {
         expect(() => Formz.validate(null), throwsA(isA<AssertionError>()));
       });
 
-      test('returns valid for empty inputs', () {
+      test('returns pure for empty inputs', () {
         final status = Formz.validate([]);
-        expect(status, equals(FormzStatus.valid));
-        expect(status.isValid, isTrue);
+        expect(status, equals(FormzStatus.pure));
+        expect(status.isValid, isFalse);
+        expect(status.isPure, isTrue);
       });
 
       test('returns valid for single valid input', () {

--- a/test/helpers/name_input.dart
+++ b/test/helpers/name_input.dart
@@ -11,3 +11,12 @@ class NameInput extends FormzInput<String, NameInputError> {
     return value?.isNotEmpty == true ? null : NameInputError.empty;
   }
 }
+
+class NameInputFormzMixin with FormzMixin {
+  NameInputFormzMixin({this.name = const NameInput.pure()});
+
+  final NameInput name;
+
+  @override
+  List<FormzInput> get inputs => [name];
+}


### PR DESCRIPTION
# 0.3.0

- Add `FormzMixin`
- Fix `Formz.validate` to take `pure` into consideration
- Lint improvements


```dart
class LoginForm with FormzMixin {
  LoginForm({
    this.username = const Username.pure(),
    this.password = const Password.pure(),
  });

  final Username username;
  final Password password;

  @override
  List<FormzInput> get inputs => [username, password];
}

final form = LoginForm();
print(form.status); // FormzStatus.pure
```
