### PR TITLE
Accept non-nullable value in validator

### DIFF
--- a/lib/formz.dart
+++ b/lib/formz.dart
@@ -144,7 +144,7 @@ abstract class FormzInput<T, E> {
 
   /// A function that must return a validation error if the provided
   /// [value] is invalid and `null` otherwise.
-  E? validator(T? value);
+  E? validator(T value);
 
   @override
   int get hashCode => value.hashCode ^ pure.hashCode;

--- a/lib/formz.dart
+++ b/lib/formz.dart
@@ -83,8 +83,8 @@ enum FormzInputStatus {
 ///   const FirstName.dirty({String value = ''}) : super.dirty(value);
 ///
 ///   @override
-///   FirstNameError validator(String value) {
-///     return value?.isNotEmpty == true ? null : FirstNameError.empty;
+///   FirstNameError? validator(String value) {
+///     return value.isEmpty ? FirstNameError.empty : null;
 ///   }
 /// }
 /// ```

--- a/test/helpers/name_input.dart
+++ b/test/helpers/name_input.dart
@@ -7,8 +7,8 @@ class NameInput extends FormzInput<String, NameInputError> {
   const NameInput.dirty({String value = ''}) : super.dirty(value);
 
   @override
-  NameInputError? validator(String? value) {
-    return value?.isNotEmpty == true ? null : NameInputError.empty;
+  NameInputError? validator(String value) {
+    return value.isEmpty ? NameInputError.empty : null;
   }
 }
 


### PR DESCRIPTION
Currently, the `validator` method doesn't allow for a non-nullable signature like `validator(String value)`. This results in an `invalid_override` message.

This PR fixes the issue by accepting both `validator(String? value)` and `validator(String value)`.
Therefore, this should not be a breaking change.